### PR TITLE
Diffrentiabilty of ExponentialFamily(ExponentialFamily.MvNormalMeanCovariance) logpdf

### DIFF
--- a/src/distributions/normal_family/normal_family.jl
+++ b/src/distributions/normal_family/normal_family.jl
@@ -667,9 +667,7 @@ getsufficientstatistics(::Type{MvNormalMeanCovariance}) = (identity, (x) -> x * 
 getlogpartition(::NaturalParametersSpace, ::Type{MvNormalMeanCovariance}) = (η) -> begin
     (η₁, η₂) = unpack_parameters(MvNormalMeanCovariance, η)
     k = length(η₁)
-    C = fastcholesky(-η₂)
-    l = logdet(C)
-    Cinv = LinearAlgebra.inv!(C)
+    Cinv, l = cholinv_logdet(-η₂)
     return (dot(η₁, Cinv, η₁) / 2 - (k * log(2) + l)) / 2
 end
 


### PR DESCRIPTION
In this PR, I've switched from using `inv!` and `logdet` in the LinearAlgebra package to `cholinv_logdet`, as the current implementation isn't differentiable with autograd. I've also added tests to verify the differentiability of the new implementation.