### PR TITLE
Update the definition of logpdf_optimized for Gaussians

### DIFF
--- a/src/distributions/normal_family/normal_family.jl
+++ b/src/distributions/normal_family/normal_family.jl
@@ -461,19 +461,11 @@ function BayesBase.compute_logscale(
     return -(v_logdet + n * log2π) / 2 - dot3arg(m, v_inv, m) / 2
 end
 
-BayesBase.logpdf_optimized(dist::UnivariateNormalDistributionsFamily) = convert(Normal, dist)
-BayesBase.logpdf_optimized(dist::MultivariateNormalDistributionsFamily) = convert(MvNormal, dist)
+BayesBase.logpdf_optimized(dist::UnivariateNormalDistributionsFamily) = convert(NormalMeanPrecision, dist)
+BayesBase.logpdf_optimized(dist::MultivariateNormalDistributionsFamily) = convert(MvNormalMeanPrecision, dist)
 
 BayesBase.sampling_optimized(dist::UnivariateNormalDistributionsFamily) = convert(Normal, dist)
 BayesBase.sampling_optimized(dist::MultivariateNormalDistributionsFamily) = convert(MvNormal, dist)
-
-function BayesBase.logpdf_sampling_optimized(
-    dist::Union{UnivariateNormalDistributionsFamily, MultivariateNormalDistributionsFamily}
-)
-    # For Gaussian both sample and logpdf are the same in terms of optimality
-    optimal = logpdf_optimized(dist)
-    return (optimal, optimal)
-end
 
 # Sample related
 


### PR DESCRIPTION
This PR changes the definition of `logpdf_optimized` for the Gaussians. The mean-precision parametrisation is better because it avoids extra inversion. Sampling is still better in `MvNormal` because they store the Cholesky factor explicitly.