### PR TITLE
Fix isapprox for Normal family of distributions

### DIFF
--- a/src/distributions/normal_family/normal_family.jl
+++ b/src/distributions/normal_family/normal_family.jl
@@ -396,10 +396,18 @@ end
 # isapprox
 
 function Base.isapprox(left::UnivariateNormalDistributionsFamily, right::UnivariateNormalDistributionsFamily; kwargs...)
+    return all(p -> isapprox(p[1], p[2]; kwargs...), zip(mean_var(left), mean_var(right)))
+end
+
+function Base.isapprox(left::D, right::D; kwargs...) where { D <: UnivariateNormalDistributionsFamily }
     return all(p -> isapprox(p[1], p[2]; kwargs...), zip(params(left), params(right)))
 end
 
 function Base.isapprox(left::MultivariateNormalDistributionsFamily, right::MultivariateNormalDistributionsFamily; kwargs...)
+    return all(p -> isapprox(p[1], p[2]; kwargs...), zip(mean_cov(left), mean_cov(right)))
+end
+
+function Base.isapprox(left::D, right::D; kwargs...) where { D <: MultivariateNormalDistributionsFamily }
     return all(p -> isapprox(p[1], p[2]; kwargs...), zip(params(left), params(right)))
 end
 

--- a/test/distributions/normal_family/mv_normal_mean_covariance_tests.jl
+++ b/test/distributions/normal_family/mv_normal_mean_covariance_tests.jl
@@ -66,6 +66,12 @@ end
     @test ndims(MvNormalMeanCovariance([0.0, 0.0, 0.0])) === 3
     @test size(MvNormalMeanCovariance([0.0, 0.0])) === (2,)
     @test size(MvNormalMeanCovariance([0.0, 0.0, 0.0])) === (3,)
+
+    distribution = MvNormalMeanCovariance([0.0, 0.0], [2.0 0.0; 0.0 3.0])
+
+    @test distribution ≈ distribution
+    @test distribution ≈ convert(MvNormalMeanPrecision, distribution)
+    @test distribution ≈ convert(MvNormalWeightedMeanPrecision, distribution)
 end
 
 @testitem "MvNormalMeanCovariance: vague" begin

--- a/test/distributions/normal_family/mv_normal_mean_precision_tests.jl
+++ b/test/distributions/normal_family/mv_normal_mean_precision_tests.jl
@@ -66,6 +66,12 @@ end
     @test ndims(MvNormalMeanPrecision([0.0, 0.0, 0.0])) === 3
     @test size(MvNormalMeanPrecision([0.0, 0.0])) === (2,)
     @test size(MvNormalMeanPrecision([0.0, 0.0, 0.0])) === (3,)
+    
+    distribution = MvNormalMeanPrecision([0.0, 0.0], [2.0 0.0; 0.0 3.0])
+
+    @test distribution ≈ distribution
+    @test distribution ≈ convert(MvNormalMeanCovariance, distribution)
+    @test distribution ≈ convert(MvNormalWeightedMeanPrecision, distribution)
 end
 
 @testitem "MvNormalMeanPrecision: vague" begin

--- a/test/distributions/normal_family/mv_normal_weighted_mean_precision_tests.jl
+++ b/test/distributions/normal_family/mv_normal_weighted_mean_precision_tests.jl
@@ -67,6 +67,12 @@ end
     @test ndims(MvNormalWeightedMeanPrecision([0.0, 0.0, 0.0])) === 3
     @test size(MvNormalWeightedMeanPrecision([0.0, 0.0])) === (2,)
     @test size(MvNormalWeightedMeanPrecision([0.0, 0.0, 0.0])) === (3,)
+
+    distribution = MvNormalWeightedMeanPrecision([0.0, 0.0], [2.0 0.0; 0.0 3.0])
+
+    @test distribution ≈ distribution
+    @test distribution ≈ convert(MvNormalMeanCovariance, distribution)
+    @test distribution ≈ convert(MvNormalMeanPrecision, distribution)
 end
 
 @testitem "MvNormalWeightedMeanPrecision: vague" begin

--- a/test/distributions/normal_family/normal_mean_precision_tests.jl
+++ b/test/distributions/normal_family/normal_mean_precision_tests.jl
@@ -104,6 +104,12 @@ end
     @test convert(NormalMeanPrecision, 0, 1) == NormalMeanPrecision{Float64}(0.0, 1.0)
     @test convert(NormalMeanPrecision, 0, 10) == NormalMeanPrecision{Float64}(0.0, 10.0)
     @test convert(NormalMeanPrecision, 0, 0.1) == NormalMeanPrecision{Float64}(0.0, 0.1)
+
+    distribution = NormalMeanPrecision(-2.0, 3.0)
+
+    @test distribution ≈ distribution
+    @test distribution ≈ convert(NormalMeanVariance, distribution)
+    @test distribution ≈ convert(NormalWeightedMeanPrecision, distribution)
 end
 
 @testitem "NormalMeanPrecision: vague" begin

--- a/test/distributions/normal_family/normal_mean_variance_tests.jl
+++ b/test/distributions/normal_family/normal_mean_variance_tests.jl
@@ -104,6 +104,12 @@ end
     @test convert(NormalMeanVariance, 0, 1) == NormalMeanVariance{Float64}(0.0, 1.0)
     @test convert(NormalMeanVariance, 0, 10) == NormalMeanVariance{Float64}(0.0, 10.0)
     @test convert(NormalMeanVariance, 0, 0.1) == NormalMeanVariance{Float64}(0.0, 0.1)
+
+    distribution = NormalMeanVariance(-2.0, 3.0)
+
+    @test distribution ≈ distribution
+    @test distribution ≈ convert(NormalMeanPrecision, distribution)
+    @test distribution ≈ convert(NormalWeightedMeanPrecision, distribution)
 end
 
 @testitem "NormalMeanVariance: vague" begin

--- a/test/distributions/normal_family/normal_weighted_mean_precision_tests.jl
+++ b/test/distributions/normal_family/normal_weighted_mean_precision_tests.jl
@@ -104,6 +104,12 @@ end
     @test convert(NormalWeightedMeanPrecision, 0, 1) == NormalWeightedMeanPrecision{Float64}(0.0, 1.0)
     @test convert(NormalWeightedMeanPrecision, 0, 10) == NormalWeightedMeanPrecision{Float64}(0.0, 10.0)
     @test convert(NormalWeightedMeanPrecision, 0, 0.1) == NormalWeightedMeanPrecision{Float64}(0.0, 0.1)
+
+    distribution = NormalWeightedMeanPrecision(-2.0, 3.0)
+
+    @test distribution ≈ distribution
+    @test distribution ≈ convert(NormalMeanPrecision, distribution)
+    @test distribution ≈ convert(NormalMeanVariance, distribution)
 end
 
 @testitem "NormalWeightedMeanPrecision: vague" begin


### PR DESCRIPTION
This PR fixes wrong `isapprox` implementation for the Gaussian distributions family